### PR TITLE
Update to Cloudflare CDN

### DIFF
--- a/src/amxprof/statistics_writer_html.cpp
+++ b/src/amxprof/statistics_writer_html.cpp
@@ -45,7 +45,7 @@ void StatisticsWriterHtml::Write(const Statistics *stats)
   "          src=\"http://code.jquery.com/jquery-latest.min.js\">\n"
   "  </script>\n"
   "  <script type=\"text/javascript\"\n"
-  "          src=\"http://tablesorter.com/__jquery.tablesorter.min.js\">\n"
+  "          src=\"https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.31.1/js/jquery.tablesorter.min.js\">\n"
   "  </script>\n"
   "  <script type=\"text/javascript\">\n"
   "    $(document).ready(function() {\n"


### PR DESCRIPTION
Current external link is not really meant to be used, change it to the cloudflare cdn and it's down a.t.m anyway (http://i.xyin.ws/i/16C850.png).